### PR TITLE
Add PDF catalog parsing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# sheldon
+# PDF Catalog Parser
+
+This project provides a simple script to convert a PDF catalog into a structured
+JSON file or a set of SQL `INSERT` statements.
+
+## Requirements
+
+Install dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python pdf_to_db.py catalog.pdf output.json
+```
+
+Use the `--sql` flag to generate SQL commands instead of JSON:
+
+```bash
+python pdf_to_db.py catalog.pdf output.sql --sql
+```
+
+The parser assumes each product is listed on a single line in the PDF with the
+format `ID, Name, Variant, Price`. Adjust the parsing logic in
+`pdf_to_db.py` to match your catalog's layout.

--- a/pdf_to_db.py
+++ b/pdf_to_db.py
@@ -1,0 +1,70 @@
+import argparse
+import json
+from pathlib import Path
+
+import pdfplumber
+
+
+def parse_pdf(pdf_path: Path):
+    """Extract products from the PDF catalog.
+
+    This example assumes each product entry is stored on a single line in the
+    format:
+    ``ID, Name, Variant, Price``.
+    Adjust the parsing logic to match your catalog's layout.
+    """
+    products = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if not text:
+                continue
+            for line in text.splitlines():
+                parts = [p.strip() for p in line.split(',')]
+                if len(parts) >= 4:
+                    product = {
+                        "id": parts[0],
+                        "name": parts[1],
+                        "variant": parts[2],
+                        "price": parts[3],
+                    }
+                    products.append(product)
+    return products
+
+
+def save_json(data, out_path: Path):
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def save_sql(data, out_path: Path):
+    with open(out_path, "w", encoding="utf-8") as f:
+        for item in data:
+            values = (
+                item["id"].replace("'", "''"),
+                item["name"].replace("'", "''"),
+                item["variant"].replace("'", "''"),
+                item["price"],
+            )
+            f.write(
+                "INSERT INTO products (id, name, variant, price) "
+                f"VALUES ('{values[0]}', '{values[1]}', '{values[2]}', '{values[3]}');\n"
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert a PDF catalog to JSON or SQL script")
+    parser.add_argument("pdf", type=Path, help="Path to the PDF catalog")
+    parser.add_argument("out", type=Path, help="Output file path")
+    parser.add_argument("--sql", action="store_true", help="Generate SQL INSERT statements instead of JSON")
+    args = parser.parse_args()
+
+    products = parse_pdf(args.pdf)
+    if args.sql:
+        save_sql(products, args.out)
+    else:
+        save_json(products, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pdfplumber
+PyPDF2


### PR DESCRIPTION
## Summary
- add a script `pdf_to_db.py` to extract products from a PDF
- describe usage in `README.md`
- specify dependencies in `requirements.txt`

## Testing
- `python -m pytest -q`
- `python pdf_to_db.py --help`


------
https://chatgpt.com/codex/tasks/task_e_685b58da3fa083309142c89100b059db