### PR TITLE
Add supplier and brand fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# sheldon
+# Sheldon Catalog Parser
+
+Prototype to parse supplier PDF catalogs and group raw text into product chunks.
+
+## Usage
+
+```
+python parser.py <catalog.pdf> <supplier_name>
+```
+
+This outputs `parsed_chunks.json` containing a list of chunks with page number,
+brand (taken from the page header) and supplier.
+
+## Database Schema
+
+The SQLite schema (`schema.sql`) defines tables for products, variants and price
+information. The `products` table now includes optional `supplier` and `brand`
+columns.
+

--- a/parser.py
+++ b/parser.py
@@ -4,20 +4,37 @@ import re
 import json
 from typing import List, Dict
 
-def extract_text_blocks(pdf_path: str) -> List[Dict]:
+
+def extract_page_brand(page) -> str:
+    """Return the page header assumed to contain the brand name."""
+    header_candidates = []
+    for b in page.get_text("blocks"):
+        x0, y0, x1, y1, text, block_no, _ = b
+        cleaned = text.strip()
+        if cleaned and cleaned.isupper() and y0 < 100:
+            header_candidates.append((y0, cleaned))
+    if header_candidates:
+        header_candidates.sort(key=lambda t: t[0])
+        return header_candidates[0][1]
+    return ""
+
+def extract_text_blocks(pdf_path: str, supplier: str = "") -> List[Dict]:
     doc = fitz.open(pdf_path)
     blocks = []
 
     for page_num, page in enumerate(doc, start=1):
+        brand = extract_page_brand(page)
         for b in page.get_text("blocks"):
-            x0, y0, x1, y1, text, block_no, _, _ = b
+            x0, y0, x1, y1, text, block_no, _ = b
             cleaned_text = text.strip()
             if cleaned_text and not is_footer_text(cleaned_text):
                 blocks.append({
                     "page": page_num,
+                    "brand": brand,
+                    "supplier": supplier,
                     "x": x0,
                     "y": y0,
-                    "text": cleaned_text
+                    "text": cleaned_text,
                 })
     return blocks
 
@@ -35,6 +52,8 @@ def group_blocks_into_chunks(blocks: List[Dict]) -> List[Dict]:
             if current_chunk:
                 chunks.append({
                     "page": current_chunk[0]["page"],
+                    "brand": current_chunk[0]["brand"],
+                    "supplier": current_chunk[0]["supplier"],
                     "x": current_chunk[0]["x"],
                     "y": current_chunk[0]["y"],
                     "text": "\n".join(b["text"] for b in current_chunk)
@@ -46,6 +65,8 @@ def group_blocks_into_chunks(blocks: List[Dict]) -> List[Dict]:
     if current_chunk:
         chunks.append({
             "page": current_chunk[0]["page"],
+            "brand": current_chunk[0]["brand"],
+            "supplier": current_chunk[0]["supplier"],
             "x": current_chunk[0]["x"],
             "y": current_chunk[0]["y"],
             "text": "\n".join(b["text"] for b in current_chunk)
@@ -57,8 +78,8 @@ def is_new_product_block(text: str) -> bool:
     # Detect new blocks using SKU pattern or strong keywords
     return bool(re.match(r"^\d{5}$", text.strip()))  # 5-digit SKU
 
-def parse_pdf_to_chunks(pdf_path: str, output_json: str = None) -> List[Dict]:
-    blocks = extract_text_blocks(pdf_path)
+def parse_pdf_to_chunks(pdf_path: str, output_json: str = None, supplier: str = "") -> List[Dict]:
+    blocks = extract_text_blocks(pdf_path, supplier)
     chunks = group_blocks_into_chunks(blocks)
 
     if output_json:
@@ -69,8 +90,9 @@ def parse_pdf_to_chunks(pdf_path: str, output_json: str = None) -> List[Dict]:
 
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) < 2:
-        print("Usage: python parser.py path_to_pdf")
+    if len(sys.argv) < 3:
+        print("Usage: python parser.py path_to_pdf supplier_name")
     else:
         pdf_file = sys.argv[1]
-        parse_pdf_to_chunks(pdf_file, "parsed_chunks.json")
+        supplier_name = sys.argv[2]
+        parse_pdf_to_chunks(pdf_file, "parsed_chunks.json", supplier_name)

--- a/schema.sql
+++ b/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS products (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
     base_sku TEXT NOT NULL,
+    supplier TEXT,
+    brand TEXT,
     tag TEXT,
     discontinued BOOLEAN DEFAULT 0
 );


### PR DESCRIPTION
## Summary
- add `supplier` and `brand` columns to `products` table
- capture page header as brand when parsing PDFs
- allow providing supplier name when running the parser
- document new fields in the README

## Testing
- `pip install --quiet pymupdf`
- `python -m py_compile parser.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc96910a883308a77197250085802