### PR TITLE
Add default PDF input/output locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# sheldon
+# Sheldon Parser
+
+This repository contains a simple PDF parser using PyMuPDF.
+
+## Usage
+
+Place PDF files in `/data/pdfs/`. Run the parser by providing the PDF file name:
+
+```bash
+python parser.py <file.pdf>
+```
+
+The parsed chunks are saved as JSON under `/output/` with the same base name.
+

--- a/parser.py
+++ b/parser.py
@@ -5,20 +5,25 @@ import json
 from typing import List, Dict
 
 def extract_text_blocks(pdf_path: str) -> List[Dict]:
-    doc = fitz.open(pdf_path)
+    """Extract text blocks from a PDF file."""
     blocks = []
-
-    for page_num, page in enumerate(doc, start=1):
-        for b in page.get_text("blocks"):
-            x0, y0, x1, y1, text, block_no, _, _ = b
-            cleaned_text = text.strip()
-            if cleaned_text and not is_footer_text(cleaned_text):
-                blocks.append({
-                    "page": page_num,
-                    "x": x0,
-                    "y": y0,
-                    "text": cleaned_text
-                })
+    # open the document using a context manager so it always closes
+    with fitz.open(pdf_path) as doc:
+        for page_num, page in enumerate(doc, start=1):
+            for b in page.get_text("blocks"):
+                # get_text("blocks") may return tuples with 7 or more
+                # elements depending on PyMuPDF version. We only need
+                # the first six values so use unpacking with a starred
+                # variable to ignore any extras.
+                x0, y0, x1, y1, text, block_no, *_ = b
+                cleaned_text = text.strip()
+                if cleaned_text and not is_footer_text(cleaned_text):
+                    blocks.append({
+                        "page": page_num,
+                        "x": x0,
+                        "y": y0,
+                        "text": cleaned_text,
+                    })
     return blocks
 
 def is_footer_text(text: str) -> bool:
@@ -57,11 +62,13 @@ def is_new_product_block(text: str) -> bool:
     # Detect new blocks using SKU pattern or strong keywords
     return bool(re.match(r"^\d{5}$", text.strip()))  # 5-digit SKU
 
-def parse_pdf_to_chunks(pdf_path: str, output_json: str = None) -> List[Dict]:
+def parse_pdf_to_chunks(pdf_path: str, output_json: str | None = None) -> List[Dict]:
+    """Parse a PDF into text chunks and optionally save as JSON."""
     blocks = extract_text_blocks(pdf_path)
     chunks = group_blocks_into_chunks(blocks)
 
     if output_json:
+        os.makedirs(os.path.dirname(output_json), exist_ok=True)
         with open(output_json, "w", encoding="utf-8") as f:
             json.dump(chunks, f, indent=2)
 
@@ -70,7 +77,12 @@ def parse_pdf_to_chunks(pdf_path: str, output_json: str = None) -> List[Dict]:
 if __name__ == "__main__":
     import sys
     if len(sys.argv) < 2:
-        print("Usage: python parser.py path_to_pdf")
+        print("Usage: python parser.py PDF_FILENAME")
     else:
-        pdf_file = sys.argv[1]
-        parse_pdf_to_chunks(pdf_file, "parsed_chunks.json")
+        pdf_name = sys.argv[1]
+        input_path = os.path.join("/data/pdfs", pdf_name)
+        base_name = os.path.splitext(pdf_name)[0] + ".json"
+        output_path = os.path.join("/output", base_name)
+
+        parse_pdf_to_chunks(input_path, output_path)
+


### PR DESCRIPTION
## Summary
- use a context manager to read PDFs
- drop unused values via starred underscore
- write output JSON under `/output` and read PDFs from `/data/pdfs`
- document usage in README

## Testing
- `pip install PyMuPDF`
- `python parser.py sample.pdf > /tmp/parsed_chunks.json && head -n 5 /output/sample.json`

------
https://chatgpt.com/codex/tasks/task_e_685cb30ccda08330b20ee7ce8ba24211